### PR TITLE
American English locale

### DIFF
--- a/js/lang/en-US.js
+++ b/js/lang/en-US.js
@@ -1,0 +1,13 @@
+var fdLocale = {
+                fullMonths:["January","February","March","April","May","June","July","August","September","October","November","December"],
+                monthAbbrs:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],
+                fullDays:  ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],
+                dayAbbrs:  ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"],
+                titles:    ["Previous month","Next month","Previous year","Next year", "Today", "Open Calendar", "wk", "Week [[%0%]] of [[%1%]]", "Week", "Select a date", "Click \u0026 Drag to move", "Display \u201C[[%0%]]\u201D first", "Go to Today\u2019s date", "Disabled date:"],
+                firstDayOfWeek:6
+};
+try { 
+        if("datePickerController" in window) { 
+                datePickerController.loadLanguage(); 
+        }; 
+} catch(err) {}; 


### PR DESCRIPTION
Thanks for writing a fantastic accessible calendar widget!  The documentation mentioned an American English locale was included, but I didn't see one, so I'm adding one here.

The only difference, as far as I can tell, is that we put our Sundays at the start of the week.
