### PR TITLE
Fix issue when tabbing past button, then clicking button.

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -2042,9 +2042,9 @@ var datePickerController = (function datePickerController() {
             };
 
             if(e.type == "keydown") {
-                datePickers[inpId].kbEvent = true;
                 var kc = e.keyCode != null ? e.keyCode : e.charCode;
-                if(kc != 13) return true; 
+                if(kc != 13) return true;
+                datePickers[inpId].kbEvent = true;
                 if(dpVisible) {
                     removeClass(this, "date-picker-button-active")                                          
                     hideAll();


### PR DESCRIPTION
As you tab past the button, kbEvent was becoming true, then when you
later click the button, it hits the return statement and doesn't
open the datepicker, or cancel the event.
