### PR TITLE
remove change listeners on destroy

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -995,6 +995,11 @@ var datePickerController = (function datePickerController() {
             removeEvent(this.table, "mouseout", o.onmouseout);
             removeEvent(document, "mousedown", o.onmousedown);
             removeEvent(document, "mouseup",   o.clearTimer);
+            
+            for (var elemId in o.formElements) {
+                var elem = document.getElementById(elemId);
+                removeEvent(elem, "change", o.changeHandler);
+              }
 
             if (window.addEventListener && !window.devicePixelRatio) {
                 try {


### PR DESCRIPTION
change listeners are added when the datepicker is created (if 'formElements' option is provided) but never removed.

This change removes the change listeners when the datepicker is removed.